### PR TITLE
Reset Environment Background Mode for GLES2 on Godot 3.1

### DIFF
--- a/scripts/hex_root.gd
+++ b/scripts/hex_root.gd
@@ -20,6 +20,14 @@ var file_to_delete = ""
 
 func _ready():
 	randomize()
+
+	# The API used below is only available starting with Godot 3.1
+	var version = Engine.get_version_info()
+	if version.major > 3 || (version.major == 3 && version.minor >= 1):
+		# GLES2 renders a black screen if WorldEnvironment background mode is "Canvas"
+		if OS.get_current_video_driver() == OS.VIDEO_DRIVER_GLES2:
+			$WorldEnvironment.environment.background_mode = Environment.BG_CLEAR_COLOR
+
 	AudioServer.set_bus_volume_db(0,-10)
 	$spiccato.volume_db = -5
 	$spiccatoB.volume_db = 0


### PR DESCRIPTION
Glow is not implemented in the GLES2 renderer, and the current settings prevent
all rendering (black screen). This hack allows playing the game on older phones,
albeit without glow effect.

----

As I told @quendera at GodotCon, the game didn't run on my phone (Samsung S3 with LineageOS 14.1, only supported OpenGL ES 2.0).

I found that it also didn't render on my laptop either (Nvidia GTX 670MX on Linux) with the default GLES2 mode, but it renders fine with GLES3. Tweaking the `WorldEnvironment` in the main scene fixed it, so I made this hack conditional so that glow still works on GLES3, but the game can be played on GLES2 too.

It might be worth changing the default renderer to GLES3 to have the glow effect, and enabling the fallback mode so that it automatically falls back to GLES2 if the device doesn't support the former. For Android, you'd have to make sure to import and export both ETC and ETC2 textures to support both render modes (if you have any texture).

Glow effects might be implemented for GLES2 in the future, but likely not in 3.1-stable.